### PR TITLE
Feat: sorting level check

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,5 @@ Option Two - use the remote hook
 
 - rename as csort is taken in pypi
 - diff generator does not report nested classes
-- prevent user for setting a method sort level higher than fixed components
-  - e.g. static method above class docstring
 - deleter decorators
-- class decorators e.g. dataclass
 - threshold for number of changes in pre-commit

--- a/docs/source/components.rst
+++ b/docs/source/components.rst
@@ -8,6 +8,8 @@ The first level of ordering depends on the type of component.
 
 The second level of ordering depends on the name of the component.
 
+.. _fixed-components-label:
+
 Fixed components
 ----------------
 There are currently four types of fixed components which cannot be manually overridden by the user.
@@ -103,6 +105,7 @@ would be converted to:
      age = 50
      last_name = "Bloggs"
 
+.. _methods-label:
 
 Methods
 -------
@@ -324,3 +327,11 @@ By default, csort sorts inner classes to the bottom of the class.
      class SecondName:
         def __init__(self, second_name: str) -> None:
             self.name = second_name
+
+Conflicts
+---------
+* If two different components are given the same sorting level then they will be sorted alphabetically.
+
+* If the sorting level for a method is set to have higher precedence than a fixed component, then a ``ValueError`` will be raised.
+
+* The ``ValueError`` can be overridden by using the ``--force`` option.

--- a/docs/source/pre_commit.rst
+++ b/docs/source/pre_commit.rst
@@ -52,6 +52,7 @@ Common amendments
     hooks:
       - id: csort
         args: ["--skip-patterns=test_", "--skip-patterns=_test.py"]
+
 * personalised configurations
     Csort in pre-commit can be configured by the user through CLI arguments or through a config
     file - see :ref:`config-label`

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -132,6 +132,12 @@ Misc
 
     See :ref:`parsing-label` for more details.
 
+
+.. option:: -f FORCE, --force FORCE
+
+    Force csort to allow manual override of sorting levels such that :ref:`methods-label` can be sorted with
+    higher precedence than :ref:`fixed-components-label`.
+
 .. _csort-group-label:
 
 Import Usage

--- a/src/csort/main.py
+++ b/src/csort/main.py
@@ -71,6 +71,14 @@ def parse_commandline() -> Tuple[argparse.Namespace, Dict[str, Any]]:
         help="Use --diff to run Csort without changing any files and print the changes which would be made.",
     )
     parser.add_argument(
+        "-f",
+        "--force",
+        default=False,
+        action="store_true",
+        help="Use --force to override exception raised if the user specifies a sorting level higher than "
+        "fixed defaults",
+    )
+    parser.add_argument(
         "-v", "--verbose", type=int, default=1, help="Set the verbosity of the Csort output. Use 0, 1, or 2."
     )
     parser.add_argument(
@@ -272,7 +280,7 @@ def main() -> None:
     cfg = update_config(cfg, args)
 
     # instantiate method describer
-    method_describer = get_method_describer(parser_type=params.parser, config=cfg)
+    method_describer = get_method_describer(parser_type=params.parser, config=cfg, override_level_check=params.force)
 
     responses: List[format_csort_response] = []
     for input_script, output_script in zip(py_scripts, outputs):

--- a/src/csort/method_describers.py
+++ b/src/csort/method_describers.py
@@ -35,12 +35,16 @@ class MethodDescriber(ABC):
 
     Attributes:
         _config: contains configurations from config file
+        _override_level_check: Defaults to False, in which case, if the user tries to set a sorting level for a
+                                non-fixed component to be higher than defaults then an exception will be raised.
+                                If True, then the exception is replaced with a warning.
         _config_to_func_map: a mapping from config keys to the appropriate function
         _method_checking_map: a mapping of a function to an ordering level
     """
 
-    def __init__(self, config: configparser.ConfigParser) -> None:
+    def __init__(self, config: configparser.ConfigParser, override_level_check: bool = False) -> None:
         self._config = config
+        self._override_level_check = override_level_check
         self._config_to_func_map: Dict[str, Callable] = self._setup_config_to_func_map()
         self._method_checking_map: Dict[Callable, int] = self._setup_func_to_level_map()
         self._instance_method_default: int = INSTANCE_METHOD_LEVEL
@@ -115,6 +119,10 @@ class MethodDescriber(ABC):
         4) Sort the mapping according to ordering level and put into OrderedDict
         Returns:
             func_to_value_map: OrderedDict with node classifying functions as keys and ordering levels as values
+
+        Raises:
+            ValueError: if max user defined sorting level is >= to a fixed default sorting level and
+                        _override_level_check is False
         """
         configs = self._config["csort.order"]
         if "instance_method" in configs:
@@ -123,6 +131,26 @@ class MethodDescriber(ABC):
         mapping: List[Tuple[Callable, int]] = []
 
         mapping.extend(self._non_method_defaults())
+
+        # check to see if the user has supplied sorting levels which conflict with the fixed defaults
+        max_default = max(map(lambda t: t[1], mapping))  # highest value from fixed defaults
+        min_user = min(map(int, configs.values()))  # lowest value from config
+        if min_user <= max_default:
+            min_user_method = [k for k, v in configs.items() if v == str(min_user)]
+            if self._override_level_check:
+                logging.warning(
+                    "The sorting level for %s is %s which is higher than max default %s. Exception overridden by "
+                    "--force option.",
+                    min_user_method,
+                    min_user,
+                    max_default,
+                )
+            else:
+                raise ValueError(
+                    "User defined sorting levels should not interfere with the fixed defaults. The lowest "
+                    f"default sorting order is {max_default} but you have defined {min_user_method} with "
+                    f"sorting level of {min_user}. Use the --force option to override this exception."
+                )
         mapping.extend([(self._config_to_func_map[method], int(value)) for method, value in configs.items()])
 
         # check if need to add any defaults

--- a/tests/unit/test_method_describer.py
+++ b/tests/unit/test_method_describer.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from typing import Callable
 
 import pytest
+from csort.generic_functions import is_class_method
 from csort.method_describers import ASTMethodDescriber
 
 
@@ -63,6 +64,20 @@ def test_ast_method_describer_init(mock_config):
         assert isinstance(value, int)
     method_levels = list(describer._method_checking_map.values())
     assert all(m in method_levels for m in list(map(int, list(mock_config["csort.order"].values()))))
+
+
+def test_ast_method_describer__setup_func_to_level_map_valueerror(mock_config):
+    mock_config["csort.order"]["class_method"] = "1"
+    with pytest.raises(ValueError):
+        ASTMethodDescriber(config=mock_config)
+
+
+def test_ast_method_describer__setup_func_to_level_map_override(mock_config, caplog):
+    mock_config["csort.order"]["class_method"] = "1"
+    describer = ASTMethodDescriber(config=mock_config, override_level_check=True)
+    msg = "The sorting level for ['class_method'] is 1 which is higher than max default 2. Exception overridden by --force option."
+    assert msg in caplog.messages
+    assert describer._method_checking_map[is_class_method] == 1
 
 
 def test_ast_method_describer_describe_method(


### PR DESCRIPTION
- Add logic to `MethodDescriber` class to check if the highest precedence user defined sorting level conflicts with the lower precedence fixed defaults. 
- The fixed defaults are in place to ensure that components such as class attributes and class level docstrings appear at the top of the class. 
- By default, csort will raise an exception if the user has requested to sort methods above the fixed defaults. 
- The exception can be bypassed by using the `--force` option